### PR TITLE
Increment version numbers and back out the framework version.

### DIFF
--- a/src/cli/hypar-cli.csproj
+++ b/src/cli/hypar-cli.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>hypar</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>win-x64,linux-x64,osx.10.12-x64</RuntimeIdentifiers>
     <Version>0.0.1-beta6</Version>
   </PropertyGroup>

--- a/src/cli/hypar-cli.csproj
+++ b/src/cli/hypar-cli.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <RuntimeIdentifiers>win-x64,linux-x64,osx.10.12-x64</RuntimeIdentifiers>
-    <Version>0.0.1-beta1</Version>
+    <Version>0.0.1-beta6</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/sdk/hypar-sdk.csproj
+++ b/src/sdk/hypar-sdk.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://www.hypar.io</PackageProjectUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
-    <Version>0.0.1-beta5</Version>
+    <Version>0.0.1-beta6</Version>
     <Tags>AEC</Tags>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR does the following:
- It increments the version numbers for `0.0.1-beta6`.
- It back the framework version of the CLI to `netcoreapp2.0` to align with Travis.