### PR TITLE
Serialization and types support.

### DIFF
--- a/csharp/src/cli/hypar-cli.csproj
+++ b/csharp/src/cli/hypar-cli.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>win-x64,linux-x64,osx.10.12-x64</RuntimeIdentifiers>
     <RuntimeFrameworkVersion>2.0.7</RuntimeFrameworkVersion>
-    <Version>0.0.2-alpha8</Version>
+    <Version>0.0.2-alpha11</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/src/sdk/Elements/Element.cs
+++ b/csharp/src/sdk/Elements/Element.cs
@@ -66,7 +66,7 @@ namespace Hypar.Elements
         /// <param name="name">The name of the parameter.</param>
         /// <param name="parameter">The parameter to add.</param>
         /// <exception cref="System.Exception">Thrown when an parameter with the same name already exists.</exception>
-        public void AddParameter<T>(string name, Parameter<T> parameter)
+        public void AddParameter(string name, Parameter parameter)
         {
             if(!_parameters.ContainsKey(name))
             {

--- a/csharp/src/sdk/Elements/Element.cs
+++ b/csharp/src/sdk/Elements/Element.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Hypar.Geometry;
+using Hypar.Elements.Serialization;
 using Newtonsoft.Json.Linq;
 
 namespace Hypar.Elements
@@ -26,10 +27,7 @@ namespace Hypar.Elements
         /// The type of the eleme]]
         /// </summary>
         [JsonProperty("type")]
-        public virtual string Type
-        {
-            get{ return "element";}
-        }
+        public abstract string Type{get;}
 
         /// <summary>
         /// A map of Parameters for the Element.
@@ -49,7 +47,7 @@ namespace Hypar.Elements
         /// <summary>
         /// The element's transform.
         /// </summary>
-        [JsonProperty("transform")]
+        [JsonIgnore]
         public Transform Transform{get; protected set;}
 
         /// <summary>

--- a/csharp/src/sdk/Elements/ElementOfType.cs
+++ b/csharp/src/sdk/Elements/ElementOfType.cs
@@ -1,0 +1,17 @@
+using Hypar.Elements.Serialization;
+using Newtonsoft.Json;
+
+namespace Hypar.Elements
+{
+    /// <summary>
+    /// Base class for all Elements which have an ElementType.
+    /// </summary>
+    public abstract class ElementOfType<TElementType> : Element
+    {  
+        /// <summary>
+        /// The ElementType of the Element.
+        /// </summary>
+        [JsonProperty("element_type")]
+        public TElementType ElementType {get; protected set;}
+    }
+}

--- a/csharp/src/sdk/Elements/ElementType.cs
+++ b/csharp/src/sdk/Elements/ElementType.cs
@@ -1,0 +1,40 @@
+using Newtonsoft.Json;
+
+namespace Hypar.Elements
+{
+    /// <summary>
+    /// Base class for all ElementTypes
+    /// </summary>
+    public abstract class ElementType
+    {
+        /// <summary>
+        /// The type of the ElementType.
+        /// Used during serialization.
+        /// </summary>
+        [JsonProperty("type")]
+        public abstract string Type{get;}
+
+        /// <summary>
+        /// The name of the ElementType.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name{get;}
+
+        /// <summary>
+        /// A description of the ElementType.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description{get;}
+
+        /// <summary>
+        /// Construct an ElementType.
+        /// </summary>
+        /// <param name="name">A name.</param>
+        /// <param name="description">A description.</param>
+        public ElementType(string name, string description = null)
+        {
+            this.Name = name;
+            this.Description = description;
+        }
+    }
+}

--- a/csharp/src/sdk/Elements/ElementType.cs
+++ b/csharp/src/sdk/Elements/ElementType.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using System;
 
 namespace Hypar.Elements
 {
@@ -7,6 +8,12 @@ namespace Hypar.Elements
     /// </summary>
     public abstract class ElementType
     {
+        /// <summary>
+        /// The unique identifier of an ElementType.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id{get;internal set;}
+
         /// <summary>
         /// The type of the ElementType.
         /// Used during serialization.
@@ -33,6 +40,7 @@ namespace Hypar.Elements
         /// <param name="description">A description.</param>
         public ElementType(string name, string description = null)
         {
+            this.Id = Guid.NewGuid().ToString();
             this.Name = name;
             this.Description = description;
         }

--- a/csharp/src/sdk/Elements/Floor.cs
+++ b/csharp/src/sdk/Elements/Floor.cs
@@ -28,7 +28,7 @@ namespace Hypar.Elements
         [JsonProperty("profile")]
         public Profile Profile
         {
-            get{return this.Transform != null ? this.Transform.OfProfile(this._profile) : this._profile;}
+            get{return this._profile;}
         }
 
         /// <summary>

--- a/csharp/src/sdk/Elements/Floor.cs
+++ b/csharp/src/sdk/Elements/Floor.cs
@@ -32,6 +32,15 @@ namespace Hypar.Elements
         }
 
         /// <summary>
+        /// The transformed Profile of the Floor.
+        /// </summary>
+        [JsonIgnore]
+        public Profile ProfileTransformed
+        {
+            get{return this.Transform != null ? this.Transform.OfProfile(this._profile) : this._profile;}
+        }
+
+        /// <summary>
         /// The elevation from which the Floor is extruded.
         /// </summary>
         [JsonProperty("elevation")]
@@ -40,7 +49,7 @@ namespace Hypar.Elements
         /// <summary>
         /// Construct a Floor.
         /// </summary>
-        /// <param name="profile">The Profile of the Floor.</param>
+        /// <param name="profile">The <see cref="Hypar.Geometry.Profile"/>of the Floor.</param>
         /// <param name="elevation">The elevation of the Floor.</param>
         /// <param name="floorType">The FloorType of the Floor.</param>
         /// <param name="material">The Floor's material.</param>

--- a/csharp/src/sdk/Elements/Floor.cs
+++ b/csharp/src/sdk/Elements/Floor.cs
@@ -62,7 +62,10 @@ namespace Hypar.Elements
         {
             var clipper = new ClipperLib.Clipper();
             clipper.AddPath(this._profile.Perimeter.ToClipperPath(), ClipperLib.PolyType.ptSubject, true);
-            clipper.AddPaths(this._profile.Voids.Select(p => p.ToClipperPath()).ToList(), ClipperLib.PolyType.ptClip, true);
+            if(this._profile.Voids != null)
+            {
+                clipper.AddPaths(this._profile.Voids.Select(p => p.ToClipperPath()).ToList(), ClipperLib.PolyType.ptClip, true);
+            }
             var solution = new List<List<ClipperLib.IntPoint>>();
             var result = clipper.Execute(ClipperLib.ClipType.ctDifference, solution, ClipperLib.PolyFillType.pftEvenOdd);
             var polys = solution.Select(s => s.ToPolygon()).ToList();

--- a/csharp/src/sdk/Elements/FloorType.cs
+++ b/csharp/src/sdk/Elements/FloorType.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace Hypar.Elements
+{
+    /// <summary>
+    /// A container for properties common to Floors.
+    /// </summary>
+    public class FloorType : ElementType
+    {
+        /// <summary>
+        /// The thickness of the Floor.
+        /// </summary>
+        public double Thickness{get;}
+
+        /// <summary>
+        /// The type of the FloorType.
+        /// </summary>
+        public override string Type
+        {
+            get{return "floor_type";}
+        }
+
+        /// <summary>
+        /// Construct a FloorType.
+        /// </summary>
+        /// <param name="name">The name of the FloorType.</param>
+        /// <param name="thickness">The thickness of the associated floor.</param>
+        /// <param name="description">A description of the FloorType.</param>
+        public FloorType(string name, double thickness, string description = null) : base(name, description)
+        {
+            if (thickness <= 0.0)
+            {
+                throw new ArgumentOutOfRangeException("thickness", "The floor type thickness must be greater than 0.0.");
+            }
+
+            this.Thickness = thickness;
+        }
+    }
+}

--- a/csharp/src/sdk/Elements/FloorType.cs
+++ b/csharp/src/sdk/Elements/FloorType.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using System;
 
 namespace Hypar.Elements
@@ -10,6 +11,7 @@ namespace Hypar.Elements
         /// <summary>
         /// The thickness of the Floor.
         /// </summary>
+        [JsonProperty("thickness")]
         public double Thickness{get;}
 
         /// <summary>

--- a/csharp/src/sdk/Elements/Mass.cs
+++ b/csharp/src/sdk/Elements/Mass.cs
@@ -29,7 +29,7 @@ namespace Hypar.Elements
         [JsonProperty("profile")]
         public Profile Profile
         {
-            get{return this.Transform != null ? this.Transform.OfProfile(this._profile) : this._profile;}
+            get{return this._profile;}
         }
 
         /// <summary>

--- a/csharp/src/sdk/Elements/Mass.cs
+++ b/csharp/src/sdk/Elements/Mass.cs
@@ -31,6 +31,15 @@ namespace Hypar.Elements
         {
             get{return this._profile;}
         }
+        
+        /// <summary>
+        /// The transformed Profile of the Mass.
+        /// </summary>
+        [JsonIgnore]
+        public Profile ProfileTransformed
+        {
+            get{return this.Transform != null ? this.Transform.OfProfile(this._profile) : this._profile;}
+        }
 
         /// <summary>
         /// The elevation of the bottom perimeter.

--- a/csharp/src/sdk/Elements/Material.cs
+++ b/csharp/src/sdk/Elements/Material.cs
@@ -11,6 +11,13 @@ namespace Hypar.Elements
     public class Material
     {   
         /// <summary>
+        /// The unique identifier of the Material.
+        /// </summary>
+        /// <value></value>
+        [JsonProperty("id")]
+        public string Id{get; internal set;}
+
+        /// <summary>
         /// The RGBA Color of the Material.
         /// </summary>
         [JsonProperty("color")]
@@ -56,6 +63,7 @@ namespace Hypar.Elements
                 throw new ArgumentOutOfRangeException("Color, specular, and glossiness values must be less than 1.0.");
             }
             
+            this.Id = Guid.NewGuid().ToString();
             this.Name = name;
             this.Color = color;
             this.SpecularFactor = specularFactor;

--- a/csharp/src/sdk/Elements/Material.cs
+++ b/csharp/src/sdk/Elements/Material.cs
@@ -2,6 +2,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections;
 using Hypar.Geometry;
+using Hypar.Elements.Serialization;
 
 namespace Hypar.Elements
 {

--- a/csharp/src/sdk/Elements/Model.cs
+++ b/csharp/src/sdk/Elements/Model.cs
@@ -88,6 +88,12 @@ namespace Hypar.Elements
                     var wall = (Wall)element;
                     AddElementType(wall.ElementType);
                 }
+
+                if(element is Floor)
+                {
+                    var floor = (Floor)element;
+                    AddElementType(floor.ElementType);
+                }
             }
             else
             {
@@ -109,13 +115,13 @@ namespace Hypar.Elements
 
         private void AddElementType(ElementType elementType)
         {
-            if(!this._elementTypes.ContainsKey(elementType.Name.ToString()))
+            if(!this._elementTypes.ContainsKey(elementType.Id))
             {
-                this._elementTypes.Add(elementType.Name, elementType);
+                this._elementTypes.Add(elementType.Id, elementType);
             }
             else
             {
-                this._elementTypes[elementType.Name] = elementType;
+                this._elementTypes[elementType.Id] = elementType;
             }
         }
 
@@ -150,31 +156,23 @@ namespace Hypar.Elements
         }
 
         /// <summary>
-        /// Get a Material by Id.
+        /// Get a Material by name.
         /// </summary>
-        /// <param name="id">The identifier of the Material.</param>
+        /// <param name="name">The name of the Material.</param>
         /// <returns>A Material or null if no Material with the specified id can be found.</returns>
-        public Material GetMaterialById(string id)
+        public Material GetMaterialByName(string name)
         {
-            if(this._materials.ContainsKey(id))
-            {
-                return this._materials[id];
-            }
-            return null;
+            return this._materials.Values.FirstOrDefault(m=>m.Name == name);
         }
 
         /// <summary>
-        /// Get an ElementType by Id.
+        /// Get an ElementType by name.
         /// </summary>
-        /// <param name="id">The identifier of the ElementType.</param>
+        /// <param name="name">The name of the ElementType.</param>
         /// <returns>An ElementType or null if no ElementType with the specified id can be found.</returns>
-        public ElementType GetElementTypeById(string id)
+        public ElementType GetElementTypeByName(string name)
         {
-            if(this._elementTypes.ContainsKey(id))
-            {
-                return this._elementTypes[id];
-            }
-            return null;
+            return this._elementTypes.Values.FirstOrDefault(et=>et.Name == name);
         }
 
         /// <summary>

--- a/csharp/src/sdk/Elements/Model.cs
+++ b/csharp/src/sdk/Elements/Model.cs
@@ -145,13 +145,13 @@ namespace Hypar.Elements
         /// <param name="material">The material to add to the model.</param>
         private void AddMaterial(Material material)
         {
-            if(!this._materials.ContainsKey(material.Name))
+            if(!this._materials.ContainsKey(material.Id))
             {
-                this._materials.Add(material.Name, material);
+                this._materials.Add(material.Id, material);
             }
             else
             {
-                this._materials[material.Name] = material;
+                this._materials[material.Id] = material;
             }
         }
 

--- a/csharp/src/sdk/Elements/Opening.cs
+++ b/csharp/src/sdk/Elements/Opening.cs
@@ -1,0 +1,64 @@
+using System;
+
+namespace Hypar.Elements
+{
+    /// <summary>
+    /// An Opening in a Wall.
+    /// </summary>
+    public class Opening
+    {
+        /// <summary>
+        /// The distance along the wall to the lower left corner of the Opening.
+        /// </summary>
+        public double DistanceAlongWall{get;}
+
+        /// <summary>
+        /// The base height of the Opening.
+        /// </summary>
+        public double BaseHeight{get;}
+
+        /// <summary>
+        /// The height of the Opening.
+        /// </summary>
+        public double Height{get;}
+
+        /// <summary>
+        /// The width of the Opening.
+        /// </summary>
+        public double Width{get;}
+
+        /// <summary>
+        /// Construct an Opening.
+        /// </summary>
+        /// <param name="distanceAlongWall">The distance along the Wall.</param>
+        /// <param name="baseHeight">The base height of the Opening.</param>
+        /// <param name="height">The height of the opening.</param>
+        /// <param name="width">The width of the opening.</param>
+        public Opening(double distanceAlongWall, double baseHeight, double height, double width)
+        {
+            if(distanceAlongWall < 0.0)
+            {
+                throw new ArgumentOutOfRangeException("The distance along the curve must be greater than 0.0.");
+            }
+
+            if(baseHeight < 0.0)
+            {
+                throw new ArgumentOutOfRangeException("The base height must be greater than 0.0.");
+            }
+
+            if(height <= 0.0)
+            {
+                throw new ArgumentOutOfRangeException("An opening's height must be greater than 0.0.");
+            }
+
+            if(width <= 0.0)
+            {
+                throw new ArgumentOutOfRangeException("An opening's width must be greater than 0.0.");
+            }
+            this.DistanceAlongWall = distanceAlongWall;
+            this.BaseHeight = baseHeight;
+            this.Height = height;
+            this.Width = width;
+        }
+    }
+}

--- a/csharp/src/sdk/Elements/Panel.cs
+++ b/csharp/src/sdk/Elements/Panel.cs
@@ -30,7 +30,7 @@ namespace Hypar.Elements
         { 
             get
             {
-                return this.Transform != null ? this._perimeter.Select(v=>this.Transform.OfPoint(v)).ToList()  : this._perimeter;
+                return this._perimeter;
             }
         }
 

--- a/csharp/src/sdk/Elements/Parameter.cs
+++ b/csharp/src/sdk/Elements/Parameter.cs
@@ -1,28 +1,42 @@
+using Hypar.Elements.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System.Runtime.Serialization;
+using System;
 
 namespace Hypar.Elements
 {
     /// <summary>
     /// ParameterValue represents both the value and the type of a parameter.
     /// </summary>
-    /// <typeparam name="TValue">The type of the value.</typeparam>
-    public abstract class Parameter<TValue>
+    [JsonConverter(typeof(ParameterConverter))]
+    public class Parameter
     {
         /// <summary>
-        /// The value of the parameter.
+        /// The value of the Parameter.
         /// </summary>
         [JsonProperty("value")]
-        public TValue Value{get;}
+        public object Value{get;}
+
+        /// <summary>
+        /// The type of the Parameter.
+        /// </summary>
+        /// <value></value>
+        public ParameterType Type{get;}
 
         /// <summary>
         /// Construct a parameter value given a value and a type.
         /// </summary>
         /// <param name="value">The value of the parameter.</param>
-        public Parameter(TValue value)
+        /// <param name="parameterType">The type of the parameter.</param>
+        public Parameter(object value, ParameterType parameterType)
         {
+            if(value.GetType() != typeof(string) && value.GetType() != typeof(double))
+            {
+                throw new ArgumentException("The provided parameter value must be a string or a double.");
+            }
             this.Value = value;
+            this.Type = parameterType;
         }
     }
 
@@ -30,7 +44,7 @@ namespace Hypar.Elements
     /// An enumeration of unit types for a numeric parameter.
     /// </summary>
     [JsonConverter(typeof(StringEnumConverter))]
-    public enum NumericParameterType
+    public enum ParameterType
     {
         /// <summary>
         /// No unit assigned.
@@ -61,43 +75,11 @@ namespace Hypar.Elements
         /// A force in Newtons.
         /// </summary>
         [EnumMember(Value = "force")]
-        Force
-    }
-
-    /// <summary>
-    /// A parameter whose value is a number.
-    /// </summary>
-    public class NumericParameter  : Parameter<double>
-    {
+        Force,
         /// <summary>
-        /// The type of the value.
+        /// A string value.
         /// </summary>
-        /// <value></value>
-        [JsonProperty("type")]
-        public NumericParameterType Type{get;}
-
-        /// <summary>
-        /// Construct a numeric parameter.
-        /// </summary>
-        /// <param name="value"></param>
-        /// <param name="type"></param>
-        /// <returns></returns>
-        public NumericParameter(double value, NumericParameterType type) : base(value)
-        {
-            this.Type = type;
-        }
-    }
-
-    /// <summary>
-    /// A parameter whose value is a string.
-    /// </summary>
-    public class StringParameter : Parameter<string>
-    {
-        /// <summary>
-        /// Construct a string parameter.
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public StringParameter(string value) : base(value){}
+        [EnumMember(Value = "text")]
+        Text
     }
 }

--- a/csharp/src/sdk/Elements/Serialization/ColorConverter.cs
+++ b/csharp/src/sdk/Elements/Serialization/ColorConverter.cs
@@ -1,0 +1,45 @@
+#pragma warning disable CS1591
+
+using Hypar.Geometry;
+using System;
+using Newtonsoft.Json;
+
+namespace Hypar.Elements.Serialization
+{
+    public class ColorConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Color);
+        }
+
+        public override bool CanRead
+        {
+            get{return false;}
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var formatting = writer.Formatting;
+            writer.Formatting = Formatting.None;
+            var c = (Color)value;
+            writer.WriteStartObject();
+            writer.WritePropertyName("red");
+            writer.WriteValue(c.Red);
+            writer.WritePropertyName("green");
+            writer.WriteValue(c.Green);
+            writer.WritePropertyName("blue");
+            writer.WriteValue(c.Blue);
+            writer.WritePropertyName("alpha");
+            writer.WriteValue(c.Alpha);
+            writer.WriteEndObject();
+            writer.Formatting = formatting;
+        }
+    }
+}

--- a/csharp/src/sdk/Elements/Serialization/ElementConverter.cs
+++ b/csharp/src/sdk/Elements/Serialization/ElementConverter.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Converters;
 using System;
 
-namespace Hypar.Elements
+namespace Hypar.Elements.Serialization
 {
 
     /// <summary>
@@ -54,19 +54,21 @@ namespace Hypar.Elements
             switch(typeName)
             {
                 case "panel":
-                    return obj.ToObject<Panel>();
+                    return obj.ToObject<Panel>(serializer);
                 case "floor":
-                    return obj.ToObject<Floor>();
+                    return obj.ToObject<Floor>(serializer);
                 case "mass":
-                    return obj.ToObject<Mass>();
+                    return obj.ToObject<Mass>(serializer);
                 case "space":
-                    return obj.ToObject<Space>();
+                    return obj.ToObject<Space>(serializer);
                 case "column":
-                    return obj.ToObject<Column>();
+                    return obj.ToObject<Column>(serializer);
                 case "beam":
-                    return obj.ToObject<Beam>();
+                    return obj.ToObject<Beam>(serializer);
                 case "brace":
-                    return obj.ToObject<Brace>();
+                    return obj.ToObject<Brace>(serializer);
+                case "wall":
+                    return obj.ToObject<Wall>(serializer);
                 default:
                     throw new Exception($"The object with type name, {typeName}, could not be deserialzed.");
             }

--- a/csharp/src/sdk/Elements/Serialization/ElementTypeConverter.cs
+++ b/csharp/src/sdk/Elements/Serialization/ElementTypeConverter.cs
@@ -45,6 +45,8 @@ namespace Hypar.Elements.Serialization
             {
                 case "wall_type":
                     return obj.ToObject<WallType>(serializer);
+                case "floor_type":
+                    return obj.ToObject<FloorType>(serializer);
                 default:
                     throw new Exception($"The ElementType with type name, {typeName}, could not be deserialzed.");
             }
@@ -118,7 +120,7 @@ namespace Hypar.Elements.Serialization
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             var et = (ElementType)value;
-            writer.WriteValue(et.Name);
+            writer.WriteValue(et.Id);
         }
     }
 }

--- a/csharp/src/sdk/Elements/Serialization/ElementTypeConverter.cs
+++ b/csharp/src/sdk/Elements/Serialization/ElementTypeConverter.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Hypar.Elements.Serialization
+{
+    public class ElementTypeConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(ElementType);
+        }
+
+        public override bool CanWrite
+        {
+            get{return false;}
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var obj = JObject.Load(reader);
+            var typeName = (string)obj.GetValue("type");
+            switch(typeName)
+            {
+                case "wall_type":
+                    return obj.ToObject<WallType>(serializer);
+                default:
+                    throw new Exception($"The ElementType with type name, {typeName}, could not be deserialzed.");
+            }
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// Converter for objects of ElementType.
+    /// </summary>
+    public class ElementTypeToIdConverter : JsonConverter
+    {
+        private Dictionary<string, ElementType> _elementTypes;
+
+        /// <summary>
+        /// Construct an ElementTypeConverter.
+        /// </summary>
+        /// <param name="elementTypes"></param>
+        public ElementTypeToIdConverter(Dictionary<string, ElementType> elementTypes)
+        {
+            this._elementTypes = elementTypes;
+        }
+
+        /// <summary>
+        /// Can this converter convert and object of type objectType?
+        /// </summary>
+        /// <param name="objectType"></param>
+        /// <returns></returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(ElementType);
+        }
+
+        /// <summary>
+        /// Read json.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="objectType"></param>
+        /// <param name="existingValue"></param>
+        /// <param name="serializer"></param>
+        /// <returns></returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var id = (string)reader.Value;
+            if(this._elementTypes.ContainsKey(id))
+            {
+                return this._elementTypes[id]; 
+            }
+            else
+            {
+                throw new Exception($"The specified ElementType, {id}, cannot be found.");
+            }
+        }
+
+        /// <summary>
+        /// Write json.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="value"></param>
+        /// <param name="serializer"></param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var et = (ElementType)value;
+            writer.WriteValue(et.Name);
+        }
+    }
+}

--- a/csharp/src/sdk/Elements/Serialization/ElementTypeConverter.cs
+++ b/csharp/src/sdk/Elements/Serialization/ElementTypeConverter.cs
@@ -5,18 +5,38 @@ using Newtonsoft.Json.Linq;
 
 namespace Hypar.Elements.Serialization
 {
+    /// <summary>
+    /// Converter for objects of type ElementType.
+    /// </summary>
     public class ElementTypeConverter : JsonConverter
     {
+        /// <summary>
+        /// Can this converter convert an object of type objectType?
+        /// </summary>
+        /// <param name="objectType"></param>
+        /// <returns></returns>
         public override bool CanConvert(Type objectType)
         {
             return objectType == typeof(ElementType);
         }
 
+        /// <summary>
+        /// Can this converter write json?
+        /// </summary>
+        /// <value></value>
         public override bool CanWrite
         {
             get{return false;}
         }
-
+        
+        /// <summary>
+        /// Read json.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="objectType"></param>
+        /// <param name="existingValue"></param>
+        /// <param name="serializer"></param>
+        /// <returns></returns>
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             var obj = JObject.Load(reader);
@@ -30,6 +50,12 @@ namespace Hypar.Elements.Serialization
             }
         }
 
+        /// <summary>
+        /// Write json.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="value"></param>
+        /// <param name="serializer"></param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
@@ -59,7 +85,7 @@ namespace Hypar.Elements.Serialization
         /// <returns></returns>
         public override bool CanConvert(Type objectType)
         {
-            return objectType == typeof(ElementType);
+            return typeof(ElementType).IsAssignableFrom(objectType);
         }
 
         /// <summary>

--- a/csharp/src/sdk/Elements/Serialization/MaterialConverter.cs
+++ b/csharp/src/sdk/Elements/Serialization/MaterialConverter.cs
@@ -60,7 +60,7 @@ namespace Hypar.Elements.Serialization
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             var material = (Material)value;
-            writer.WriteValue(material.Name);
+            writer.WriteValue(material.Id);
         }
     }
 }

--- a/csharp/src/sdk/Elements/Serialization/MaterialConverter.cs
+++ b/csharp/src/sdk/Elements/Serialization/MaterialConverter.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Hypar.Elements.Serialization
+{
+    /// <summary>
+    /// Converts a Material to its identifier and back.
+    /// </summary>
+    public class MaterialToIdConverter : JsonConverter
+    {
+        private Dictionary<string, Material> _materials;
+
+        /// <summary>
+        /// Construct a MaterialConverter.
+        /// </summary>
+        /// <param name="materials">A collection of Materials.</param>
+        public MaterialToIdConverter(Dictionary<string, Material> materials)
+        {
+            this._materials = materials;
+        }
+
+        /// <summary>
+        /// Can this converter convert an object of type objectType?
+        /// </summary>
+        /// <param name="objectType"></param>
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Material);
+        }
+
+        /// <summary>
+        /// Read json.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="objectType"></param>
+        /// <param name="existingValue"></param>
+        /// <param name="serializer"></param>
+        /// <returns></returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var id = (string)reader.Value;
+            if(this._materials.ContainsKey(id))
+            {
+                return this._materials[id]; 
+            }
+            else
+            {
+                throw new Exception($"The specified material, {id}, cannot be found.");
+            }
+        }
+
+        /// <summary>
+        /// Write json.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="value"></param>
+        /// <param name="serializer"></param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var material = (Material)value;
+            writer.WriteValue(material.Name);
+        }
+    }
+}

--- a/csharp/src/sdk/Elements/Serialization/ModelConverter.cs
+++ b/csharp/src/sdk/Elements/Serialization/ModelConverter.cs
@@ -75,11 +75,11 @@ namespace Hypar.Elements.Serialization
             writer.WriteRawValue(JsonConvert.SerializeObject(model.Elements, new JsonSerializerSettings(){
                 Formatting = Formatting.Indented,
                 Converters = new JsonConverter[]
-                            {
-                                new ElementConverter(), 
-                                new MaterialToIdConverter(model.Materials),
-                                new ElementTypeToIdConverter(model.ElementTypes)
-                            }
+                    {
+                        new ElementConverter(), 
+                        new MaterialToIdConverter(model.Materials),
+                        new ElementTypeToIdConverter(model.ElementTypes)
+                    }
             }));
             
             // Serialize materials

--- a/csharp/src/sdk/Elements/Serialization/ModelConverter.cs
+++ b/csharp/src/sdk/Elements/Serialization/ModelConverter.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Hypar.Elements.Serialization
+{
+    /// <summary>
+    /// Convert a Model.
+    /// </summary>
+    public class ModelConverter : JsonConverter
+    {
+        /// <summary>
+        /// Can this converter convert and object of type objectType?
+        /// </summary>
+        /// <param name="objectType"></param>
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Model);
+        }
+
+        /// <summary>
+        /// Read json.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="objectType"></param>
+        /// <param name="existingValue"></param>
+        /// <param name="serializer"></param>
+        /// <returns></returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var obj = JObject.Load(reader);
+            var materials = JsonConvert.DeserializeObject<Dictionary<string,Material>>(obj.GetValue("materials").ToString());
+            var elementTypes = JsonConvert.DeserializeObject<Dictionary<string,ElementType>>(obj.GetValue("element_types").ToString(), 
+                                new []{new ElementTypeConverter()});
+            var elements = JsonConvert.DeserializeObject<Dictionary<string,Element>>(obj.GetValue("elements").ToString(),
+                            new JsonSerializerSettings()
+                            {
+                                Converters = new JsonConverter[]
+                                                {
+                                                    new ElementConverter(),
+                                                    new MaterialToIdConverter(materials),
+                                                    new ElementTypeToIdConverter(elementTypes)
+                                                },
+                                Formatting = Formatting.Indented
+                            });                                                
+            return new Model(elements, materials, elementTypes);
+        }
+
+        /// <summary>
+        /// Write json.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="value"></param>
+        /// <param name="serializer"></param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var model = (Model)value;
+            writer.WriteStartObject();
+
+            // Write materials
+            writer.WritePropertyName("materials");
+            writer.WriteRawValue(JsonConvert.SerializeObject(model.Materials, new JsonSerializerSettings(){
+                Formatting = Formatting.Indented
+            }));
+
+            // Write element types
+            writer.WritePropertyName("element_types");
+            writer.WriteRawValue(JsonConvert.SerializeObject(model.ElementTypes, new JsonSerializerSettings(){
+                Formatting = Formatting.Indented
+            }));
+
+            // Write elements
+            writer.WritePropertyName("elements");
+            writer.WriteRawValue(JsonConvert.SerializeObject(model.Elements, new JsonSerializerSettings(){
+                Formatting = Formatting.Indented,
+                Converters = new JsonConverter[]
+                            {
+                                new ElementConverter(), 
+                                new MaterialToIdConverter(model.Materials),
+                                new ElementTypeToIdConverter(model.ElementTypes)
+                            }
+            }));
+            
+            // Serialize materials
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/csharp/src/sdk/Elements/Serialization/ModelConverter.cs
+++ b/csharp/src/sdk/Elements/Serialization/ModelConverter.cs
@@ -79,7 +79,8 @@ namespace Hypar.Elements.Serialization
                         new ElementConverter(), 
                         new MaterialToIdConverter(model.Materials),
                         new ElementTypeToIdConverter(model.ElementTypes)
-                    }
+                    },
+                NullValueHandling = NullValueHandling.Ignore
             }));
             
             // Serialize materials

--- a/csharp/src/sdk/Elements/Serialization/ParameterConverter.cs
+++ b/csharp/src/sdk/Elements/Serialization/ParameterConverter.cs
@@ -1,0 +1,39 @@
+#pragma warning disable CS1591
+
+using System;
+using Newtonsoft.Json;
+
+namespace Hypar.Elements.Serialization
+{
+    public class ParameterConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Parameter);
+        }
+
+        public override bool CanRead
+        {
+            get{return false;}
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var formatting = writer.Formatting;
+            writer.Formatting = Formatting.None;
+            var v = (Parameter)value;
+            writer.WriteStartObject();
+            writer.WritePropertyName("type");
+            writer.WriteValue(v.Type);
+            writer.WritePropertyName("value");
+            writer.WriteValue(v.Value);
+            writer.WriteEndObject();
+            writer.Formatting = formatting;
+        }
+    }
+}

--- a/csharp/src/sdk/Elements/Serialization/Vector3Converter.cs
+++ b/csharp/src/sdk/Elements/Serialization/Vector3Converter.cs
@@ -1,0 +1,76 @@
+#pragma warning disable CS1591
+
+using Hypar.Geometry;
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Hypar.Elements.Serialization
+{
+    public class Vector3Converter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Vector3);
+        }
+
+        public override bool CanRead
+        {
+            get{return false;}
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var formatting = writer.Formatting;
+            writer.Formatting = Formatting.None;
+            var v = (Vector3)value;
+            writer.WriteStartObject();
+            writer.WritePropertyName("x");
+            writer.WriteValue(v.X);
+            writer.WritePropertyName("y");
+            writer.WriteValue(v.Y);
+            writer.WritePropertyName("z");
+            writer.WriteValue(v.Z);
+            writer.WriteEndObject();
+            writer.Formatting = formatting;
+        }
+    }
+
+    public class PolygonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Polygon);
+        }
+
+        public override bool CanRead
+        {
+            get{return false;}
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var p = (Polygon)value;
+
+            var formatting = writer.Formatting;
+            writer.Formatting = Formatting.None;
+            writer.WriteStartObject();
+            // writer.WriteWhitespace("\n");
+            writer.WritePropertyName("vertices");
+            writer.WriteRawValue(JsonConvert.SerializeObject(p.Vertices));
+            // writer.WriteWhitespace("\n");
+            writer.WriteEndObject();
+            writer.Formatting = formatting;
+        }
+    }
+}

--- a/csharp/src/sdk/Elements/Space.cs
+++ b/csharp/src/sdk/Elements/Space.cs
@@ -45,6 +45,15 @@ namespace Hypar.Elements
         }
 
         /// <summary>
+        /// The transformed Profile of the Space.
+        /// </summary>
+        [JsonIgnore]
+        public Profile TransformedProfile
+        {
+            get{return this.Transform != null ? this.Transform.OfProfile(this._profile) : this._profile;}
+        }
+
+        /// <summary>
         /// Construct a space.
         /// </summary>
         /// <param name="profile">The Profile of the space.</param>

--- a/csharp/src/sdk/Elements/Space.cs
+++ b/csharp/src/sdk/Elements/Space.cs
@@ -17,6 +17,7 @@ namespace Hypar.Elements
         /// <summary>
         /// The type of the element.
         /// </summary>
+        [JsonProperty("type")]
         public override string Type
         {
             get { return "space"; }
@@ -40,7 +41,7 @@ namespace Hypar.Elements
         [JsonProperty("profile")]
         public Profile Profile
         {
-            get { return this.Transform != null? this.Transform.OfProfile(this._profile) : this._profile; }
+            get { return this._profile; }
         }
 
         /// <summary>

--- a/csharp/src/sdk/Elements/StructuralFraming.cs
+++ b/csharp/src/sdk/Elements/StructuralFraming.cs
@@ -35,7 +35,7 @@ namespace Hypar.Elements
         [JsonProperty("center_line")]
         public Line CenterLine
         {
-            get { return this.Transform != null ? this.Transform.OfLine(this._centerLine) : this._centerLine; }
+            get { return this._centerLine; }
         }
 
         /// <summary>

--- a/csharp/src/sdk/Elements/StructuralFraming.cs
+++ b/csharp/src/sdk/Elements/StructuralFraming.cs
@@ -26,7 +26,7 @@ namespace Hypar.Elements
         /// <summary>
         /// The up axis of the framing element.
         /// </summary>
-        [JsonProperty("up_axis")]
+        [JsonIgnore]
         public Vector3 UpAxis { get; }
 
         /// <summary>

--- a/csharp/src/sdk/Elements/Wall.cs
+++ b/csharp/src/sdk/Elements/Wall.cs
@@ -9,7 +9,7 @@ namespace Hypar.Elements
     /// <summary>
     /// A wall is a building element which is used to enclose space.
     /// </summary>
-    public class Wall : Element, ITessellate<Mesh>
+    public class Wall : ElementOfType<WallType>, ITessellate<Mesh>
     {
         private readonly Line _centerLine;
 
@@ -21,7 +21,7 @@ namespace Hypar.Elements
         [JsonProperty("profile")]
         public Profile Profile
         {
-            get{return this.Transform != null ? this.Transform.OfProfile(this._profile) : this._profile;}
+            get{ return this._profile; }
         }
 
         /// <summary>
@@ -30,41 +30,37 @@ namespace Hypar.Elements
         [JsonProperty("center_line")]
         public Line CenterLine
         {
-            get{return this.Transform != null ? this.Transform.OfLine(this._centerLine) : this._centerLine;}
+            get{ return this._centerLine;}
         }
-
-        /// <summary>
-        /// The thickness of the wall.
-        /// </summary>
-        /// <value></value>
-        [JsonProperty("thickness")]
-        public double Thickness { get; set; }
 
         /// <summary>
         /// The height of the wall.
         /// </summary>
-        /// <value></value>
         [JsonProperty("height")]
         public double Height { get; }
 
         /// <summary>
+        /// The type of the Element.
+        /// </summary>
+        [JsonProperty("type")]
+        public override string Type
+        {
+            get{return "wall";}
+        }
+
+        /// <summary>
         /// Construct a wall along a line.
         /// </summary>
-        /// <param name="centerLine">The center line of the wall.</param>
-        /// <param name="thickness">The thickness of the wall.</param>
-        /// <param name="height">The height of the wall.</param>
+        /// <param name="centerLine">The center line of the Wall.</param>
+        /// <param name="wallType">The WallType of the Wall.</param>
+        /// <param name="height">The height of the Wall.</param>
         /// <param name="openings">A collection of Openings in the Wall.</param>
-        /// <param name="material">The wall's material.</param>
+        /// <param name="material">The Wall's material.</param>
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the thickness of the Wall is less than or equal to zero.</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the height of the Wall is less than or equal to zero.</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the Z components of Wall's start and end points are not the same.</exception>
-        public Wall(Line centerLine, double thickness, double height, IList<Opening> openings = null, Material material = null)
+        public Wall(Line centerLine, WallType wallType, double height, IList<Opening> openings = null, Material material = null)
         {
-            if (thickness <= 0.0)
-            {
-                throw new ArgumentOutOfRangeException("The wall could not be constructed. The thickness of the wall must be greater than 0.0.");
-            }
-
             if (height <= 0.0)
             {
                 throw new ArgumentOutOfRangeException("The wall could not be constructed. The height of the wall must be greater than 0.0.");
@@ -76,10 +72,10 @@ namespace Hypar.Elements
             }
 
             this._centerLine = centerLine;
-            this.Thickness = thickness;
             this.Material = material == null ? BuiltInMaterials.Concrete : material;
             this.Height = height;
-
+            this.ElementType = wallType;
+            
             if(openings != null && openings.Count > 0)
             {
                 var voids = openings.Select(o=>Polygon.Rectangle(new Vector3(o.DistanceAlongWall, o.BaseHeight), new Vector3(o.DistanceAlongWall + o.Width, o.BaseHeight + o.Height))).ToList();
@@ -100,7 +96,7 @@ namespace Hypar.Elements
         /// </summary>
         public Mesh Tessellate()
         {
-            return Mesh.Extrude(this._profile.Perimeter, this.Thickness, this._profile.Voids, true);
+            return Mesh.Extrude(this._profile.Perimeter, this.ElementType.Thickness, this._profile.Voids, true);
         }
     }
 }

--- a/csharp/src/sdk/Elements/Wall.cs
+++ b/csharp/src/sdk/Elements/Wall.cs
@@ -16,12 +16,21 @@ namespace Hypar.Elements
         private readonly Profile _profile;
 
         /// <summary>
-        /// The Profile of the wall.
+        /// The Profile of the Wall.
         /// </summary>
         [JsonProperty("profile")]
         public Profile Profile
         {
             get{ return this._profile; }
+        }
+
+        /// <summary>
+        /// The transformed Profile of the Wall.
+        /// </summary>
+        [JsonIgnore]
+        public Profile ProfileTransformed
+        {
+            get{return this.Transform != null? this.Transform.OfProfile(this._profile) : this._profile;}
         }
 
         /// <summary>

--- a/csharp/src/sdk/Elements/Wall.cs
+++ b/csharp/src/sdk/Elements/Wall.cs
@@ -1,6 +1,8 @@
 using Hypar.Geometry;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Hypar.Elements
 {
@@ -11,10 +13,20 @@ namespace Hypar.Elements
     {
         private readonly Line _centerLine;
 
+        private readonly Profile _profile;
+
+        /// <summary>
+        /// The Profile of the wall.
+        /// </summary>
+        [JsonProperty("profile")]
+        public Profile Profile
+        {
+            get{return this.Transform != null ? this.Transform.OfProfile(this._profile) : this._profile;}
+        }
+
         /// <summary>
         /// The center line of the wall.
         /// </summary>
-        /// <value></value>
         [JsonProperty("center_line")]
         public Line CenterLine
         {
@@ -41,11 +53,12 @@ namespace Hypar.Elements
         /// <param name="centerLine">The center line of the wall.</param>
         /// <param name="thickness">The thickness of the wall.</param>
         /// <param name="height">The height of the wall.</param>
+        /// <param name="openings">A collection of Openings in the Wall.</param>
         /// <param name="material">The wall's material.</param>
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the thickness of the Wall is less than or equal to zero.</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the height of the Wall is less than or equal to zero.</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the Z components of Wall's start and end points are not the same.</exception>
-        public Wall(Line centerLine, double thickness, double height, Material material = null)
+        public Wall(Line centerLine, double thickness, double height, IList<Opening> openings = null, Material material = null)
         {
             if (thickness <= 0.0)
             {
@@ -66,15 +79,28 @@ namespace Hypar.Elements
             this.Thickness = thickness;
             this.Material = material == null ? BuiltInMaterials.Concrete : material;
             this.Height = height;
+
+            if(openings != null && openings.Count > 0)
+            {
+                var voids = openings.Select(o=>Polygon.Rectangle(new Vector3(o.DistanceAlongWall, o.BaseHeight), new Vector3(o.DistanceAlongWall + o.Width, o.BaseHeight + o.Height))).ToList();
+                this._profile = new Profile(Polygon.Rectangle(Vector3.Origin, new Vector3(centerLine.Length, height)), voids);
+            }
+            else
+            {
+                this._profile = new Profile(Polygon.Rectangle(Vector3.Origin, new Vector3(centerLine.Length, height)));
+            }
+            
+            // Construct a transform whose X axis is the centerline of the wall.
+            var z = centerLine.Direction.Cross(Vector3.ZAxis);
+            this.Transform = new Transform(centerLine.Start, centerLine.Direction, z);
         }
 
         /// <summary>
         /// Generate a mesh of the wall.
         /// </summary>
-        /// <returns></returns>
         public Mesh Tessellate()
         {
-            return Mesh.Extrude(this._centerLine.Thicken(this.Thickness), this.Height);
+            return Mesh.Extrude(this._profile.Perimeter, this.Thickness, this._profile.Voids, true);
         }
     }
 }

--- a/csharp/src/sdk/Elements/WallType.cs
+++ b/csharp/src/sdk/Elements/WallType.cs
@@ -1,0 +1,41 @@
+using Newtonsoft.Json;
+using System;
+
+namespace Hypar.Elements
+{
+    /// <summary>
+    /// A container for properties common to Walls.
+    /// </summary>
+    public class WallType : ElementType
+    {
+        /// <summary>
+        /// The thickness of the Wall.
+        /// </summary>
+        [JsonProperty("thickness")]
+        public double Thickness{get;}
+
+        /// <summary>
+        /// The Type of the ElementType.
+        /// </summary>
+        public override string Type
+        {
+            get{return "wall_type";}
+        }
+
+        /// <summary>
+        /// Construct a WallType.
+        /// </summary>
+        /// <param name="name">The name of the WallType.</param>
+        /// <param name="thickness">The thickness for all Walls of this WallType.</param>
+        /// <param name="description">The description of the WallType.</param>
+        /// <returns></returns>
+        public WallType(string name, double thickness, string description = null) : base(name, description)
+        {
+            if (thickness <= 0.0)
+            {
+                throw new ArgumentOutOfRangeException("The WallType could not be constructed. The thickness of the WallType must be greater than 0.0.");
+            }
+            this.Thickness = thickness;
+        }
+    }
+}

--- a/csharp/src/sdk/Geometry/Color.cs
+++ b/csharp/src/sdk/Geometry/Color.cs
@@ -1,3 +1,4 @@
+using Hypar.Elements.Serialization;
 using Newtonsoft.Json;
 using System;
 
@@ -6,6 +7,7 @@ namespace Hypar.Geometry
     /// <summary>
     /// Color represents an RGBA color.
     /// </summary>
+    [JsonConverter(typeof(ColorConverter))]
     public class Color
     {
         /// <summary>

--- a/csharp/src/sdk/Geometry/Line.cs
+++ b/csharp/src/sdk/Geometry/Line.cs
@@ -37,7 +37,7 @@ namespace Hypar.Geometry
         /// <summary>
         /// Get a normalized vector representing the direction of the line.
         /// </summary>
-        [JsonProperty("direction")]
+        [JsonIgnore]
         public Vector3 Direction
         {
             get

--- a/csharp/src/sdk/Geometry/Polygon.cs
+++ b/csharp/src/sdk/Geometry/Polygon.cs
@@ -1,4 +1,5 @@
 using ClipperLib;
+using Hypar.Elements.Serialization;
 using Newtonsoft.Json;
 using System;
 using System.Collections;
@@ -10,6 +11,7 @@ namespace Hypar.Geometry
     /// <summary>
     /// A closed planar polygon.
     /// </summary>
+    // [JsonConverter(typeof(PolygonConverter))]
     public partial class Polygon : ICurve
     {
         private IList<Vector3> _vertices;
@@ -18,7 +20,7 @@ namespace Hypar.Geometry
         /// The area enclosed by the polygon.
         /// </summary>
         /// <value></value>
-        [JsonProperty("area")]
+        [JsonIgnore]
         public double Area
         {
             get {
@@ -45,7 +47,7 @@ namespace Hypar.Geometry
         /// <summary>
         /// The length of the polygon.
         /// </summary>
-        [JsonProperty("length")]
+        [JsonIgnore]
         public double Length
         {
             get{return this.Segments().Sum(s=>s.Length);}

--- a/csharp/src/sdk/Geometry/Polygons.cs
+++ b/csharp/src/sdk/Geometry/Polygons.cs
@@ -17,7 +17,7 @@ namespace Hypar.Geometry
         /// <param name="height"></param>
         /// <param name="verticalOffset"></param>
         /// <param name="horizontalOffset"></param>
-        /// <returns></returns>
+        /// <returns>A rectangular Polygon centered around origin.</returns>
         public static Polygon Rectangle(Vector3 origin = null, double width = 1.0, double height = 1.0, double verticalOffset = 0.0, double horizontalOffset = 0.0)
         {
             if(origin == null)
@@ -34,15 +34,59 @@ namespace Hypar.Geometry
         }
 
         /// <summary>
+        /// Construct a Polygon.
+        /// </summary>
+        /// <param name="min">The minimum coordinate.</param>
+        /// <param name="max">The maximum coordinate.</param>
+        /// <returns>A rectangular Polygon with its lower left corner at min and its upper right corner at max.</returns>
+        public static Polygon Rectangle(Vector3 min, Vector3 max)
+        {
+            var a = min;
+            var b = new Vector3(max.X,min.Y);
+            var c = max;
+            var d = new Vector3(min.X, max.Y);
+
+            return new Polygon(new[]{a, b, c, d});
+        }
+
+        /// <summary>
         /// A circle.
         /// </summary>
         /// <param name="radius">The radius of the circle.</param>
         /// <param name="divisions">The number of divisions of the circle.</param>
-        /// <returns></returns>
+        /// <returns>A circle as a Polygon tessellated into the specified number of divisions.</returns>
         public static Polygon Circle(double radius = 1.0, int divisions = 10)
         {
             var verts = new List<Vector3>();
             for(var i=0.0; i<Math.PI*2; i += Math.PI*2/divisions)
+            {
+                verts.Add(new Vector3(radius * Math.Cos(i), radius * Math.Sin(i)));
+            }
+            return new Polygon(verts);
+        }
+
+        /// <summary>
+        /// Construct a Polygon.
+        /// </summary>
+        /// <param name="sides">The number of side of the Polygon.</param>
+        /// <param name="radius">The radius of the circle in which the Ngon is inscribed.</param>
+        /// <returns>A Polygon with the specified number of sides.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the radius is less than or equal to zero.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the number of sides is less than 3.</exception>
+        public static Polygon Ngon(int sides, double radius)
+        {
+            if(radius <= 0.0)
+            {
+                throw new ArgumentOutOfRangeException("The radius must be greater than 0.0.");
+            }
+
+            if(sides < 3)
+            {
+                throw new ArgumentOutOfRangeException("The number of sides must be greater than 3.");
+            }
+
+            var verts = new List<Vector3>();
+            for(var i=0.0; i<Math.PI*2; i += Math.PI*2/sides)
             {
                 verts.Add(new Vector3(radius * Math.Cos(i), radius * Math.Sin(i)));
             }

--- a/csharp/src/sdk/Geometry/Profile.cs
+++ b/csharp/src/sdk/Geometry/Profile.cs
@@ -94,7 +94,7 @@ namespace Hypar.Geometry
         public Profile(Polygon perimeter)
         {
             this.Perimeter = perimeter;
-            this.Voids = new List<Polygon>();
+            // this.Voids = new List<Polygon>();
         }
         
         /// <summary>

--- a/csharp/src/sdk/Geometry/Transform.cs
+++ b/csharp/src/sdk/Geometry/Transform.cs
@@ -51,6 +51,7 @@ namespace Hypar.Geometry
         /// <summary>
         /// The XY plane of the Transform.
         /// </summary>
+        [JsonIgnore]
         public Plane XY
         {
             get{return new Plane(this.Origin, this.ZAxis);}
@@ -59,7 +60,7 @@ namespace Hypar.Geometry
         /// <summary>
         /// The YZ plane of the Transform.
         /// </summary>
-        /// <value></value>
+        [JsonIgnore]
         public Plane YZ
         {
             get{return new Plane(this.Origin, this.XAxis);}
@@ -68,7 +69,7 @@ namespace Hypar.Geometry
         /// <summary>
         /// The XZ plane of the Transform.
         /// </summary>
-        /// <value></value>
+        [JsonIgnore]
         public Plane XZ
         {
             get{return new Plane(this.Origin, this.YAxis);}

--- a/csharp/src/sdk/Geometry/Vector3.cs
+++ b/csharp/src/sdk/Geometry/Vector3.cs
@@ -1,3 +1,4 @@
+using Hypar.Elements.Serialization;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -8,6 +9,7 @@ namespace Hypar.Geometry
     /// <summary>
     /// A 3D vector.
     /// </summary>
+    [JsonConverter(typeof(Vector3Converter))]
     public class Vector3
     {
         /// <summary>

--- a/csharp/src/sdk/GltfExtensions.cs
+++ b/csharp/src/sdk/GltfExtensions.cs
@@ -137,7 +137,7 @@ namespace Hypar
             
             while(buffer.Count() % 4 != 0)
             {
-                Console.WriteLine("Padding...");
+                // Console.WriteLine("Padding...");
                 buffer.Add(0);
             }
 

--- a/csharp/src/sdk/hypar-sdk.csproj
+++ b/csharp/src/sdk/hypar-sdk.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://www.hypar.io</PackageProjectUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
-    <Version>0.0.2-alpha9</Version>
+    <Version>0.0.2-alpha11</Version>
     <Tags>AEC</Tags>
   </PropertyGroup>
 

--- a/csharp/test/Hypar.SDK.Tests/FloorTests.cs
+++ b/csharp/test/Hypar.SDK.Tests/FloorTests.cs
@@ -15,7 +15,8 @@ namespace Hypar.Tests
             var p = Polygon.Rectangle(Vector3.Origin, 5, 5);
             var p1 = Polygon.Rectangle(new Vector3(3,2,0), 3, 1);
             var profile = new Profile(p, p1);
-            var floor = new Floor(profile, 0.0, 0.2);
+            var floorType = new FloorType("test", 0.2);
+            var floor = new Floor(profile, floorType, 0.0);
             var model = new Model();
             model.AddElement(floor);
             model.SaveGlb("floor.glb");
@@ -26,9 +27,10 @@ namespace Hypar.Tests
         {
             var p = Polygon.Rectangle();
             var profile = new Profile(p);
-            var floor = new Floor(profile, 1.0, 0.2);
+            var floorType = new FloorType("test", 0.2);
+            var floor = new Floor(profile, floorType, 1.0);
             Assert.Equal(1.0, floor.Elevation);
-            Assert.Equal(0.2, floor.Thickness);
+            Assert.Equal(0.2, floor.ElementType.Thickness);
             Assert.Equal(1.0, floor.Transform.Origin.Z);
         }
 
@@ -37,7 +39,7 @@ namespace Hypar.Tests
         {
             var model = new Model();
             var poly = Polygon.Rectangle(width:20, height:20);
-            Assert.Throws<ArgumentOutOfRangeException>(()=> new Floor(new Profile(poly), 0.0, 0.0));
+            Assert.Throws<ArgumentOutOfRangeException>(()=> {var floorType = new FloorType("test", 0.0);});
         }
 
         [Fact]
@@ -47,7 +49,8 @@ namespace Hypar.Tests
             var p1 = Polygon.Rectangle(new Vector3(1,1,0), 1, 1);
             var p2 = Polygon.Rectangle(new Vector3(3,3,0), 1, 1);
             var profile = new Profile(Polygon.Rectangle(Vector3.Origin, 10, 10), new[]{p1,p2});
-            var floor = new Floor(profile, 0.0, 0.2, BuiltInMaterials.Concrete);
+            var floorType = new FloorType("test", 0.2);
+            var floor = new Floor(profile, floorType, 0.0, BuiltInMaterials.Concrete);
             Assert.Equal(100.0-2.0, floor.Area());
         }
     }

--- a/csharp/test/Hypar.SDK.Tests/IntegrationTests.cs
+++ b/csharp/test/Hypar.SDK.Tests/IntegrationTests.cs
@@ -46,7 +46,8 @@ namespace Hypar.Tests
                 }
             }
 
-            var floors = mass.Floors(elevations, 0.2, BuiltInMaterials.Concrete);
+            var floorType = new FloorType("test", 0.2);
+            var floors = mass.Floors(elevations, floorType, BuiltInMaterials.Concrete);
             model.AddElements(floors);
 
             var shaft = Polygon.Rectangle(new Vector3(10,10), 5, 5);

--- a/csharp/test/Hypar.SDK.Tests/IntegrationTests.cs
+++ b/csharp/test/Hypar.SDK.Tests/IntegrationTests.cs
@@ -51,7 +51,7 @@ namespace Hypar.Tests
 
             var shaft = Polygon.Rectangle(new Vector3(10,10), 5, 5);
             var walls = shaft.Segments().Select(l=>{
-                return new Wall(l, 0.1, buildingHeight, BuiltInMaterials.Concrete);
+                return new Wall(l, 0.1, buildingHeight, null, BuiltInMaterials.Concrete);
             });
             model.AddElements(walls);
 

--- a/csharp/test/Hypar.SDK.Tests/IntegrationTests.cs
+++ b/csharp/test/Hypar.SDK.Tests/IntegrationTests.cs
@@ -50,8 +50,9 @@ namespace Hypar.Tests
             model.AddElements(floors);
 
             var shaft = Polygon.Rectangle(new Vector3(10,10), 5, 5);
+            var shaftWallType = new WallType("ShaftWall", 0.1);
             var walls = shaft.Segments().Select(l=>{
-                return new Wall(l, 0.1, buildingHeight, null, BuiltInMaterials.Concrete);
+                return new Wall(l, shaftWallType, buildingHeight, null, BuiltInMaterials.Concrete);
             });
             model.AddElements(walls);
 

--- a/csharp/test/Hypar.SDK.Tests/MassTests.cs
+++ b/csharp/test/Hypar.SDK.Tests/MassTests.cs
@@ -84,9 +84,10 @@ namespace Hypar.Tests
             var mass3 = new Mass(profile3, 20.0, 10.0, material3);
             model.AddElements(new[]{mass1,mass2,mass3});
             
-            var f1 = new Floor(profile1, 0.0, 0.2);
-            var f2 = new Floor(profile2, 10.0, 0.2);
-            var f3 = new Floor(profile3, 20.0, 0.2);
+            var floorType = new FloorType("test", 0.2);
+            var f1 = new Floor(profile1, floorType, 0.0);
+            var f2 = new Floor(profile2, floorType, 10.0);
+            var f3 = new Floor(profile3, floorType, 20.0);
             model.AddElements(new[]{f1,f2,f3});
 
             model.SaveGlb("transformed_masses.glb");

--- a/csharp/test/Hypar.SDK.Tests/MassTests.cs
+++ b/csharp/test/Hypar.SDK.Tests/MassTests.cs
@@ -109,7 +109,7 @@ namespace Hypar.Tests
             mass.Transform.Move(t);
             for(var i=0; i<profile.Vertices.Count; i++)
             {
-                Assert.Equal(profile.Vertices[i] + t, mass.Profile.Perimeter.Vertices[i]);
+                Assert.Equal(profile.Vertices[i] + t, mass.Profile.Perimeter.Vertices[i] + t);
             }
         }
     }

--- a/csharp/test/Hypar.SDK.Tests/ModelTests.cs
+++ b/csharp/test/Hypar.SDK.Tests/ModelTests.cs
@@ -53,17 +53,23 @@ namespace Hypar.Tests
             var spaceProfile = new Profile(Polygon.Rectangle(), Polygon.Rectangle(new Vector3(2,2), 1.0, 1.0));
             var space = new Space(spaceProfile, 5.0, 5.0);
             var model = new Model();
-            model.AddElements(new Element[]{panel, floor, mass, beam, column, space});
+
+            var wallLine = new Line(Vector3.Origin, new Vector3(10,0,0));
+            var wallType = new WallType("test", 0.1, "A test wall type.");
+            var wall = new Wall(wallLine, wallType, 4.0);
+
+            model.AddElements(new Element[]{panel, floor, mass, beam, column, space, wall});
             var json = model.ToJson();
-            // Console.WriteLine(json);
+            Console.WriteLine(json);
 
             var newModel = Model.FromJson(json);
-            var elements = newModel.Values;
-            var newPanel = elements.OfType<Panel>().FirstOrDefault();
-            var newFloor = elements.OfType<Floor>().FirstOrDefault();
-            var newMass = elements.OfType<Mass>().FirstOrDefault();
-            var newBeam = elements.OfType<Beam>().FirstOrDefault();
-            var newSpace = elements.OfType<Space>().FirstOrDefault();
+            var elements = newModel.Elements;
+            var newPanel = elements.Values.OfType<Panel>().FirstOrDefault();
+            var newFloor = elements.Values.OfType<Floor>().FirstOrDefault();
+            var newMass = elements.Values.OfType<Mass>().FirstOrDefault();
+            var newBeam = elements.Values.OfType<Beam>().FirstOrDefault();
+            var newSpace = elements.Values.OfType<Space>().FirstOrDefault();
+            var newWall = elements.Values.OfType<Wall>().FirstOrDefault();
 
             Assert.Equal(panel.Perimeter.Count, newPanel.Perimeter.Count);
             Assert.Equal(panel.Id, newPanel.Id);
@@ -78,6 +84,9 @@ namespace Hypar.Tests
             Assert.Equal(space.Elevation, newSpace.Elevation);
             Assert.Equal(space.Height, newSpace.Height);
             Assert.Equal(space.Profile.Perimeter, newSpace.Profile.Perimeter);
+            Assert.Equal(wall.Height, newWall.Height);
+            Assert.Equal(wall.CenterLine, newWall.CenterLine);
+            Assert.Equal(wall.ElementType, model.GetElementTypeById("test"));
         }
 
         private Model QuadPanelModel()

--- a/csharp/test/Hypar.SDK.Tests/ModelTests.cs
+++ b/csharp/test/Hypar.SDK.Tests/ModelTests.cs
@@ -45,7 +45,8 @@ namespace Hypar.Tests
             panel.AddParameter("param2", new NumericParameter(42.0, NumericParameterType.Force));
 
             var profile = new Profile(Polygon.Rectangle(), Polygon.Rectangle(new Vector3(2,2), 1.0, 1.0));
-            var floor = new Floor(profile, 5.0, 0.2);
+            var floorType = new FloorType("test", 0.2);
+            var floor = new Floor(profile, floorType, 5.0);
             var mass = new Mass(Polygon.Rectangle(), 5.0, 1.0);
             var line = new Line(Vector3.Origin, new Vector3(5,5,5));
             var beam = new Beam(line, new WideFlangeProfile(), BuiltInMaterials.Steel);
@@ -76,7 +77,7 @@ namespace Hypar.Tests
             Assert.Equal(floor.Id, newFloor.Id);
             Assert.Equal(floor.Material, newFloor.Material);
             Assert.Equal(floor.Profile.Perimeter.Vertices.Count, newFloor.Profile.Perimeter.Vertices.Count);
-            Assert.Equal(floor.Thickness, newFloor.Thickness);
+            Assert.Equal(floor.ElementType.Thickness, newFloor.ElementType.Thickness);
             Assert.Equal(floor.Elevation, newFloor.Elevation);
             Assert.Equal(mass.Profile.Perimeter.Vertices.Count, newMass.Profile.Perimeter.Vertices.Count);
             Assert.Equal(mass.Elevation, newMass.Elevation);
@@ -86,7 +87,7 @@ namespace Hypar.Tests
             Assert.Equal(space.Profile.Perimeter, newSpace.Profile.Perimeter);
             Assert.Equal(wall.Height, newWall.Height);
             Assert.Equal(wall.CenterLine, newWall.CenterLine);
-            Assert.Equal(wall.ElementType, model.GetElementTypeById("test"));
+            Assert.Equal(wall.ElementType, model.ElementTypes[newWall.ElementType.Id]);
         }
 
         private Model QuadPanelModel()

--- a/csharp/test/Hypar.SDK.Tests/ModelTests.cs
+++ b/csharp/test/Hypar.SDK.Tests/ModelTests.cs
@@ -41,8 +41,8 @@ namespace Hypar.Tests
             var c = new Vector3(1,0,1);
             var d = new Vector3(0,0,1);
             var panel = new Panel(new []{a,b,c,d,}, BuiltInMaterials.Glass);
-            panel.AddParameter("param1", new NumericParameter(42.0, NumericParameterType.Area));
-            panel.AddParameter("param2", new NumericParameter(42.0, NumericParameterType.Force));
+            panel.AddParameter("param1", new Parameter(42.0, ParameterType.Area));
+            panel.AddParameter("param2", new Parameter(42.0, ParameterType.Force));
 
             var profile = new Profile(Polygon.Rectangle(), Polygon.Rectangle(new Vector3(2,2), 1.0, 1.0));
             var floorType = new FloorType("test", 0.2);

--- a/csharp/test/Hypar.SDK.Tests/SpaceTests.cs
+++ b/csharp/test/Hypar.SDK.Tests/SpaceTests.cs
@@ -43,7 +43,7 @@ namespace Hypar.Tests
             var p1 = space.Profile.Perimeter;
             for(var i=0; i<p.Vertices.Count; i++)
             {
-                Assert.Equal(p.Vertices[i] + t, p1.Vertices[i]);
+                Assert.Equal(p.Vertices[i] + t, p1.Vertices[i] + t);
             }
         }
     }

--- a/csharp/test/Hypar.SDK.Tests/WallTests.cs
+++ b/csharp/test/Hypar.SDK.Tests/WallTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Hypar.Elements;
 using Hypar.Geometry;
 using Xunit;
@@ -10,13 +11,18 @@ namespace Hypar.Tests
         [Fact]
         public void Example()
         {
-            var a = Vector3.Origin;
-            var b = new Vector3(0.0, 5.0);
-            var line = new Line(a,b);
-            var wall = new Wall(line, 0.1, 5.0);
-
             var model = new Model();
-            model.AddElement(wall);
+
+            var triangle = Polygon.Ngon(7, 15.0);
+            var openings = new List<Opening>();
+            openings.Add(new Opening(1.0, 1.0, 2.0, 1.0));
+            openings.Add(new Opening(4.0, 0.0, 2.0, 1.0));
+            foreach(var l in triangle.Segments())
+            {
+                var w = new Wall(l, 0.1, 5.0, openings);
+                model.AddElement(w);
+            }
+            
             model.SaveGlb("wall.glb");
         }
 
@@ -45,6 +51,28 @@ namespace Hypar.Tests
             var b = new Vector3(0.0, 5.0, 5.0);
             var line = new Line(a,b);
             Assert.Throws<ArgumentException>(()=>new Wall(line, 0.1, 5.0));
+        }
+
+        [Fact]
+        public void NullOpenings_ProfileWithNoVoids()
+        {
+            var a = Vector3.Origin;
+            var b = new Vector3(0.0, 5.0);
+            var line = new Line(a,b);
+            var wall = new Wall(line, 0.1, 4.0);
+            Assert.Equal(0, wall.Profile.Voids.Count);
+        }
+
+        [Fact]
+        public void TwoOpenings_ProfileWithTwoOpenings()
+        {
+            var a = Vector3.Origin;
+            var b = new Vector3(0.0, 5.0);
+            var line = new Line(a,b);
+            var o1 = new Opening(1.0, 0.0, 2.0, 1.0);
+            var o2 = new Opening(3.0, 1.0, 1.0, 1.0);
+            var wall = new Wall(line, 0.1, 4.0, new []{o1,o2});
+            Assert.Equal(2, wall.Profile.Voids.Count);
         }
     }
 }

--- a/csharp/test/Hypar.SDK.Tests/WallTests.cs
+++ b/csharp/test/Hypar.SDK.Tests/WallTests.cs
@@ -12,6 +12,7 @@ namespace Hypar.Tests
         public void Example()
         {
             var model = new Model();
+            var testWallType = new WallType("test", 0.1);
 
             var triangle = Polygon.Ngon(7, 15.0);
             var openings = new List<Opening>();
@@ -19,7 +20,7 @@ namespace Hypar.Tests
             openings.Add(new Opening(4.0, 0.0, 2.0, 1.0));
             foreach(var l in triangle.Segments())
             {
-                var w = new Wall(l, 0.1, 5.0, openings);
+                var w = new Wall(l, testWallType, 5.0, openings);
                 model.AddElement(w);
             }
             
@@ -32,7 +33,8 @@ namespace Hypar.Tests
             var a = Vector3.Origin;
             var b = new Vector3(0.0, 5.0);
             var line = new Line(a,b);
-            Assert.Throws<ArgumentOutOfRangeException>(()=>new Wall(line, 0.1, 0.0));
+            var testWallType = new WallType("test", 0.1);
+            Assert.Throws<ArgumentOutOfRangeException>(()=>new Wall(line, testWallType, 0.0));
         }
 
         [Fact]
@@ -41,7 +43,7 @@ namespace Hypar.Tests
             var a = Vector3.Origin;
             var b = new Vector3(0.0, 5.0);
             var line = new Line(a,b);
-            Assert.Throws<ArgumentOutOfRangeException>(()=>new Wall(line, 0.0, 5.0));
+            Assert.Throws<ArgumentOutOfRangeException>(()=>{var testWallType = new WallType("test", 0.0);});
         }
 
         [Fact]
@@ -50,7 +52,8 @@ namespace Hypar.Tests
             var a = Vector3.Origin;
             var b = new Vector3(0.0, 5.0, 5.0);
             var line = new Line(a,b);
-            Assert.Throws<ArgumentException>(()=>new Wall(line, 0.1, 5.0));
+            var testWallType = new WallType("test", 0.1);
+            Assert.Throws<ArgumentException>(()=>new Wall(line, testWallType, 5.0));
         }
 
         [Fact]
@@ -59,7 +62,8 @@ namespace Hypar.Tests
             var a = Vector3.Origin;
             var b = new Vector3(0.0, 5.0);
             var line = new Line(a,b);
-            var wall = new Wall(line, 0.1, 4.0);
+            var testWallType = new WallType("test", 0.1);
+            var wall = new Wall(line, testWallType, 4.0);
             Assert.Equal(0, wall.Profile.Voids.Count);
         }
 
@@ -71,7 +75,8 @@ namespace Hypar.Tests
             var line = new Line(a,b);
             var o1 = new Opening(1.0, 0.0, 2.0, 1.0);
             var o2 = new Opening(3.0, 1.0, 1.0, 1.0);
-            var wall = new Wall(line, 0.1, 4.0, new []{o1,o2});
+            var testWallType = new WallType("test", 0.1);
+            var wall = new Wall(line, testWallType, 4.0, new []{o1,o2});
             Assert.Equal(2, wall.Profile.Voids.Count);
         }
     }

--- a/csharp/test/Hypar.SDK.Tests/WallTests.cs
+++ b/csharp/test/Hypar.SDK.Tests/WallTests.cs
@@ -64,7 +64,7 @@ namespace Hypar.Tests
             var line = new Line(a,b);
             var testWallType = new WallType("test", 0.1);
             var wall = new Wall(line, testWallType, 4.0);
-            Assert.Equal(0, wall.Profile.Voids.Count);
+            Assert.Null(wall.Profile.Voids);
         }
 
         [Fact]


### PR DESCRIPTION
This PR contains numerous fixes:
- The addition of `WallType` and `FloorType` to store information for types reused across many instances of Floors and Walls. 
- Serialization of materials and element types to dedicated blocks in json to reduce json size.
- Small changes to properties to return un-transformed geometry with the addition of other properties to return the transformed versions.